### PR TITLE
Do not add `nextToken` for mutations.

### DIFF
--- a/serverless_crud/builders/graphql.py
+++ b/serverless_crud/builders/graphql.py
@@ -82,7 +82,7 @@ class SchemaBuilder:
         def mutate_(parent, info, input):
             return model(id=str(uuid.uuid4()), created=23423423, user=str(uuid.uuid4()))
 
-        InputArguments = type("Arguments", (), {"input": input_dto(required=True), "nextToken": graphene.String()})
+        InputArguments = type("Arguments", (), {"input": input_dto(required=True)})
         IdArguments = type("Arguments", (), {"id": graphene.String(required=True)})
 
         mutations = {}


### PR DESCRIPTION
`nextToken` field is not needed for mutations, hence why it can be removed.