### PR TITLE
Add option to use Cognito username instead of sub as identity

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,7 @@ def dynamo():
                     "Projection": {"ProjectionType": "ALL"},
                 },
             ],
+            BillingMode="PAY_PER_REQUEST",
         )
 
         table = dynamo.Table("Device")

--- a/events/appsync/listDevice.json
+++ b/events/appsync/listDevice.json
@@ -1,6 +1,6 @@
 {
   "typeName": "Query",
-  "fieldName": "listDevices",
+  "fieldName": "listDevice",
   "arguments": {},
   "identity": {
     "claims": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ isort = "^5.10"
 troposphere = "^3.2.2"
 pytest = "~6.2"
 moto = "~3.0"
+pytest-freezegun = "^0.4.2"
 
 [tool.black]
 line-length = 120

--- a/serverless_crud/actions/base.py
+++ b/serverless_crud/actions/base.py
@@ -11,8 +11,9 @@ from serverless_crud.utils import identity
 
 
 class Action(abc.ABC):
-    def __init__(self, model):
+    def __init__(self, model, username_is_identity: bool = False):
         self.model: type(BaseModel) = model
+        self.username_is_identity: bool = username_is_identity
 
     def __call__(self, *args, **kwargs):
         return self.handle(*args, **kwargs)
@@ -28,7 +29,7 @@ class Action(abc.ABC):
         if not self.model._meta.owner_field:
             return payload
 
-        payload[self.model._meta.owner_field] = identity(event)
+        payload[self.model._meta.owner_field] = identity(event, use_username=self.username_is_identity)
 
         return payload
 

--- a/serverless_crud/actions/delete.py
+++ b/serverless_crud/actions/delete.py
@@ -14,7 +14,7 @@ class DeleteAction(Action):
 
         params["ConditionExpression"] = f"#user = :user"
         params["ExpressionAttributeNames"] = {"#user": self.model._meta.owner_field}
-        params["ExpressionAttributeValues"] = {":user": identity(event)}
+        params["ExpressionAttributeValues"] = {":user": identity(event, use_username=self.username_is_identity)}
 
     @with_dynamodb
     def handle(self, primary_key, event: APIGatewayProxyEvent, context, table, dynamodb, *args, **kwargs):

--- a/serverless_crud/actions/get.py
+++ b/serverless_crud/actions/get.py
@@ -24,7 +24,9 @@ class GetAction(Action):
             if not item:
                 raise EntityNotFoundException()
 
-            if self.model._meta.owner_field and item.get(self.model._meta.owner_field) != identity(event):
+            if self.model._meta.owner_field and item.get(self.model._meta.owner_field) != identity(
+                event, use_username=self.username_is_identity
+            ):
                 raise EntityNotFoundException()
 
             return response, item

--- a/serverless_crud/actions/search.py
+++ b/serverless_crud/actions/search.py
@@ -45,7 +45,7 @@ class SearchAction(Action, ABC):
 
         query[owner_filter_namespace] = expression + f"#{self.model._meta.owner_field} = :owner"
         attributes = query.get("ExpressionAttributeValues", {})
-        attributes.update({":owner": identity(event)})
+        attributes.update({":owner": identity(event, use_username=self.username_is_identity)})
         query["ExpressionAttributeValues"] = attributes
 
         names = query.get("ExpressionAttributeNames", {})

--- a/serverless_crud/actions/update.py
+++ b/serverless_crud/actions/update.py
@@ -26,7 +26,7 @@ class UpdateAction(Action):
         if self.model._meta.owner_field not in primary_key.raw().keys():
             query["ConditionExpression"] = "#owner = :owner"
             query["ExpressionAttributeNames"]["#owner"] = self.model._meta.owner_field
-            query["ExpressionAttributeValues"][":owner"] = identity(event)
+            query["ExpressionAttributeValues"][":owner"] = identity(event, use_username=self.username_is_identity)
 
         try:
             result = table.update_item(**query)

--- a/serverless_crud/utils.py
+++ b/serverless_crud/utils.py
@@ -6,13 +6,20 @@ def identity(event, use_username):
     owner = "anon."
     try:
         if use_username:
+            username = None
             if event.get("identity", {}).get("username"):
-                return event.get("identity", {}).get("username")
-            claims = event.get("requestContext", {}).get("authorizer", {}).get("claims")
-            if not claims:
-                claims = event.get("identity", {}).get("claims")
-            if claims.get("cognito:username", claims.get("username")):
-                owner = claims.get("cognito:username", claims.get("username"))
+                username = event.get("identity", {}).get("username")
+            else:
+                claims = event.get("requestContext", {}).get("authorizer", {}).get("claims")
+                if not claims:
+                    claims = event.get("identity", {}).get("claims")
+                if claims.get("cognito:username", claims.get("username")):
+                    username = claims.get("cognito:username", claims.get("username"))
+            if username:
+                if username == owner:
+                    raise ValueError("User has the same username as the reserved word for unauthenticated identity.")
+                else:
+                    owner = username
             return owner
 
         if event.get("requestContext", {}).get("authorizer", {}).get("claims", {}).get("sub"):

--- a/test/appsync/test_queries.py
+++ b/test/appsync/test_queries.py
@@ -20,7 +20,7 @@ def test_get_missing_device(app):
 
 
 def test_list_devices(app):
-    mock_event = load_event("appsync/listDevices.json")
+    mock_event = load_event("appsync/listDevice.json")
 
     result = app.appsync.handle(mock_event, {})
 

--- a/test/test_generic.py
+++ b/test/test_generic.py
@@ -1,16 +1,23 @@
+import pytest
+
 from serverless_crud.utils import identity
 from test.utils import load_event
 
 
+@pytest.mark.freeze_time("2022-01-19T23:07:25Z")
 def test_identify():
     event = load_event("appsync/createDevice.json")
-    assert identity(event) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=False) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=True) == "michal"
 
     event = load_event("graphql/getDevice_cognito.json")
-    assert identity(event) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=False) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=True) == "michal"
 
     event = load_event("graphql/getDevice_iam.json")
-    assert identity(event) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=False) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=True) == "anon."  # No username/cognito:username with IAM
 
     event = load_event("rest/get.json")
-    assert identity(event) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=False) == "0b44ac7a-c793-4e4d-9b2d-0634be07598f"
+    assert identity(event, use_username=True) == "791791ac-b6c7-454e-89d0-927850869d06"


### PR DESCRIPTION
- Added new option for actions to use the Cognito username instead of sub attribute of a user.
- Fixed tests.